### PR TITLE
composer.json correction for packagist.org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-	"name"        : "abeautifulsite/SimpleImage",
+	"name"        : "abeautifulsite/simpleimage",
 	"description" : "A PHP class that simplifies working with images",
 	"license"     : [
-		"GPL-3.0+",
+		"GPL-2.0",
 		"MIT"
 	],
 	"version"     : "2.3.0",


### PR DESCRIPTION
Now packagist.org should accept this repository.
Also, new versions will be autoatically grabbed by packagist.org if add corresponding hook.
Composer will be really the simplest way to use SimpleImage.
