### PR TITLE
Better composer usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
 	"license"     : [
 		"MIT"
 	],
-	"version"     : "2.5.0",
 	"require"     : {
 		"php" : ">=5.3.0"
 	},
@@ -24,6 +23,11 @@
 	"autoload"    : {
 		"psr-0" : {
 			"abeautifulsite" : "src/"
+		}
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "2.5-dev"
 		}
 	}
 }


### PR DESCRIPTION
It is more _right way_ to tag specific versions with tags, and create alias for master branch so that anyone will be able to get latest _dev_ version of _2.5_ series
