### PR TITLE
Remove redundant destructor call, fixes #15

### DIFF
--- a/src/abeautifulsite/SimpleImage.php
+++ b/src/abeautifulsite/SimpleImage.php
@@ -58,6 +58,7 @@ class SimpleImage {
 	function __destruct() {
 		if ($this->image) {
 			imagedestroy($this->image);
+            $this->image = null;
 		}
 	}
 	
@@ -625,10 +626,6 @@ class SimpleImage {
 				throw new Exception('Unsupported image format: '.$this->filename);
 				break;
 		}
-		
-		// Since no more output can be sent, call the destructor to free up memory
-		$this->__destruct();
-		
 	}
 	
 	/**


### PR DESCRIPTION
Unlike the claim in the issue, #15 was never fixed in the code, in any version. Lines have been removed from the output call and the image resource will be set to `null` after it has been destroyed, as it should be.