### PR TITLE
Allow setting $format in save() method

### DIFF
--- a/src/abeautifulsite/SimpleImage.php
+++ b/src/abeautifulsite/SimpleImage.php
@@ -851,17 +851,18 @@ class SimpleImage {
 	 *
 	 * @param null|string	$filename	If omitted - original file will be overwritten
 	 * @param null|int		$quality	Output image quality in percents 0-100
+	 * @param null|string	$format		If omitted or null - format of original file will be used, may be gif|jpg|png
 	 *
 	 * @return SimpleImage
 	 * @throws Exception
 	 *
 	 */
-	function save($filename = null, $quality = null) {
+	function save($filename = null, $quality = null, $format = null) {
 		
 		// Determine quality, filename, and format
 		$quality = $quality ?: $this->quality;
 		$filename = $filename ?: $this->filename;
-		$format = $this->file_ext($filename) ?: $this->original_info['format'];
+		$format = $format ?: $this->file_ext($filename) ?: $this->original_info['format'];
 		
 		// Create the image
 		switch (strtolower($format)) {


### PR DESCRIPTION
I'm usually working on temporary files which are given arbitrary names and a "tmp" extension. I needed a way to overwrite the format detection (which is based on file name's extension) in the save() method. I added a optional $format variable. Usage is consistent with the output() method.