### PR TITLE
Update SimpleImage.php

### DIFF
--- a/src/abeautifulsite/SimpleImage.php
+++ b/src/abeautifulsite/SimpleImage.php
@@ -56,7 +56,7 @@ class SimpleImage {
      *
      */
     function __destruct() {
-        if( get_resource_type($this->image) === 'gd' ) {
+        if( $this->image !== null && get_resource_type($this->image) === 'gd' ) {
             imagedestroy($this->image);
         }
     }


### PR DESCRIPTION
Prevent warning for the case the class was created without arguments.

    Warning: get_resource_type() expects parameter 1 to be resource, null given in [...] on line 59