### PR TITLE
Fixed exif warnings

### DIFF
--- a/src/abeautifulsite/SimpleImage.php
+++ b/src/abeautifulsite/SimpleImage.php
@@ -1244,7 +1244,7 @@ class SimpleImage {
         $info = Array();
         $match_exif = Array();
 
-        getimagesize($this->filename, $info);
+        $format_info = getimagesize($this->filename, $info);
 
         $exif = null;
 
@@ -1253,7 +1253,7 @@ class SimpleImage {
         {
             preg_match("/^exif/i", $info['APP1'], $match_exif);
 
-            if(!empty($match_exif) && function_exists('exif_read_data') && $info['mime'] === 'image/jpeg' &&
+            if(!empty($match_exif) && function_exists('exif_read_data') && $format_info['mime'] === 'image/jpeg' &&
                 $this->imagestring === null)
             {
                 $exif = exif_read_data($this->filename);

--- a/src/abeautifulsite/SimpleImage.php
+++ b/src/abeautifulsite/SimpleImage.php
@@ -1221,7 +1221,7 @@ class SimpleImage {
             'width' => $info[0],
             'height' => $info[1],
             'orientation' => $this->get_orientation(),
-            'exif' => function_exists('exif_read_data') && $info['mime'] === 'image/jpeg' && $this->imagestring === null ? $this->exif = @exif_read_data($this->filename) : null,
+            'exif' => $this->get_exif_data(),
             'format' => preg_replace('/^image\//', '', $info['mime']),
             'mime' => $info['mime']
         );
@@ -1233,6 +1233,34 @@ class SimpleImage {
 
         return $this;
 
+    }
+
+    /***
+     * Get the exif data from image if are defined.
+     *
+     * @return array|null
+     */
+    protected function get_exif_data() {
+        $info = Array();
+        $match_exif = Array();
+
+        getimagesize($this->filename, $info);
+
+        $exif = null;
+
+        //Check if exif data can be retrieved (to avoid warnings from exif_read_data)
+        if(isset($info['APP1']))
+        {
+            preg_match("/^exif/i", $info['APP1'], $match_exif);
+
+            if(!empty($match_exif) && function_exists('exif_read_data') && $info['mime'] === 'image/jpeg' &&
+                $this->imagestring === null)
+            {
+                $exif = exif_read_data($this->filename);
+            }
+        }
+
+        return $exif;
     }
 
     /**


### PR DESCRIPTION
Added a separate method 'get_exif_data' to retrieve the exif data in a safe way, what that method does is check if the image have exif data before use 'exif_read_data' (http://php.net/manual/en/function.exif-read-data.php) to retrieve it and this prevents the warning thrown by 'exif_read_data' if the given image don't have exif data.
