### PR TITLE
Refactored output and save method

### DIFF
--- a/src/abeautifulsite/SimpleImage.php
+++ b/src/abeautifulsite/SimpleImage.php
@@ -311,6 +311,50 @@ class SimpleImage {
     }
 
     /**
+     * Crop to fit
+     *
+     * Center crop image and then resize it to fit within specified dimensions
+     *
+     * @param int           $crop_width
+     * @param int           $crop_height
+     *
+     * @return SimpleImage
+     *
+     */
+    function crop_to_fit( $c2f_width, $c2f_height ) {
+
+        // If it already fits, there's nothing to do
+        if ($this->width == $c2f_width && $this->height == $c2f_height) {
+            return $this;
+        }
+
+        // Determine aspect ratio
+        $aspect_ratio = $this->height / $this->width;
+
+        // landscape
+        if( $aspect_ratio < 1 )
+        {
+            $x1 = ( $this->width - $this->height ) / 2;
+            $x2 = $x1 + $this->height;
+            $y1 = 0;
+            $y2 = $this->height;
+            $this->crop( $x1, $y1, $x2, $y2 );
+        }
+        // portrait
+        elseif( $aspect_ratio > 1 )
+        {
+            $x1 = 0;
+            $x2 = $this->width;
+            $y1 = ( $this->height - $this->width ) / 2;
+            $y2 = $y1 + $this->width;
+            $this->crop( $x1, $y1, $x2, $y2 );
+        }
+
+        return $this->resize( $c2f_width, $c2f_height );
+
+    }
+
+    /**
      * Desaturate
      *
      * @param int           $percentage Level of desaturization.

--- a/src/abeautifulsite/SimpleImage.php
+++ b/src/abeautifulsite/SimpleImage.php
@@ -311,50 +311,6 @@ class SimpleImage {
     }
 
     /**
-     * Crop to fit
-     *
-     * Center crop image and then resize it to fit within specified dimensions
-     *
-     * @param int           $crop_width
-     * @param int           $crop_height
-     *
-     * @return SimpleImage
-     *
-     */
-    function crop_to_fit( $c2f_width, $c2f_height ) {
-
-        // If it already fits, there's nothing to do
-        if ($this->width == $c2f_width && $this->height == $c2f_height) {
-            return $this;
-        }
-
-        // Determine aspect ratio
-        $aspect_ratio = $this->height / $this->width;
-
-        // landscape
-        if( $aspect_ratio < 1 )
-        {
-            $x1 = ( $this->width - $this->height ) / 2;
-            $x2 = $x1 + $this->height;
-            $y1 = 0;
-            $y2 = $this->height;
-            $this->crop( $x1, $y1, $x2, $y2 );
-        }
-        // portrait
-        elseif( $aspect_ratio > 1 )
-        {
-            $x1 = 0;
-            $x2 = $this->width;
-            $y1 = ( $this->height - $this->width ) / 2;
-            $y2 = $y1 + $this->width;
-            $this->crop( $x1, $y1, $x2, $y2 );
-        }
-
-        return $this->resize( $c2f_width, $c2f_height );
-
-    }
-
-    /**
      * Desaturate
      *
      * @param int           $percentage Level of desaturization.

--- a/src/abeautifulsite/SimpleImage.php
+++ b/src/abeautifulsite/SimpleImage.php
@@ -639,9 +639,6 @@ class SimpleImage {
                 break;
         }
 
-        // Sets image mimetype
-        $this->mimetype = $mimetype;
-
         // Sets the image data
         ob_start();
         switch ($mimetype) {
@@ -658,10 +655,10 @@ class SimpleImage {
                 throw new Exception('Unsupported image format: '.$this->filename);
                 break;
         }
-        $this->imagestring = ob_get_contents();
+        $imagestring = ob_get_contents();
         ob_end_clean();
 
-        return $this;
+        return [ $mimetype, $imagestring ];
     }
 
     /**
@@ -675,11 +672,11 @@ class SimpleImage {
      */
     function output($format = null, $quality = null) {
 
-        $this->generate( $format, $quality );
+        list( $mimetype, $imagestring ) = $this->generate( $format, $quality );
 
         // Output the image
-        header('Content-Type: '.$this->mimetype);
-        echo $this->imagestring;
+        header('Content-Type: '.$mimetype);
+        echo $imagestring;
     }
 
     /**
@@ -694,10 +691,10 @@ class SimpleImage {
      */
     function output_base64($format = null, $quality = null) {
 
-        $this->generate( $format, $quality );
+        list( $mimetype, $imagestring ) = $this->generate( $format, $quality );
 
         // Returns formatted string for img src
-        return 'data:'.$this->mimetype.';base64,'.base64_encode($this->imagestring);
+        return "data:{$mimetype};base64,".base64_encode($imagestring);
 
     }
 
@@ -876,10 +873,10 @@ class SimpleImage {
         if( !$format )
             $format = $this->file_ext($filename) ?: $this->original_info['format'];
 
-        $this->generate( $format, $quality );
+        list( $mimetype, $imagestring ) = $this->generate( $format, $quality );
 
         // Save the image
-        $result = file_put_contents( $filename, $this->imagestring );
+        $result = file_put_contents( $filename, $imagestring );
         if (!$result)
             throw new Exception('Unable to save image: ' . $filename);
 

--- a/src/abeautifulsite/SimpleImage.php
+++ b/src/abeautifulsite/SimpleImage.php
@@ -26,7 +26,7 @@ class SimpleImage {
      */
     public $quality = 80;
 
-    protected $image, $filename, $original_info, $width, $height, $imagestring;
+    protected $image, $filename, $original_info, $width, $height, $imagestring, $mimetype;
 
     /**
      * Create instance and load an image, or create an image from scratch
@@ -497,6 +497,13 @@ class SimpleImage {
     }
 
     /**
+     * Generates an image
+     *
+     * @return int
+     *
+     */
+
+    /**
      * Get the current height
      *
      * @return int
@@ -643,7 +650,7 @@ class SimpleImage {
     }
 
     /**
-     * Outputs image without saving
+     * Generates the image as a string it and sets mime type
      *
      * @param null|string   $format     If omitted or null - format of original file will be used, may be gif|jpg|png
      * @param int|null      $quality    Output image quality in percents 0-100
@@ -651,7 +658,7 @@ class SimpleImage {
      * @throws Exception
      *
      */
-    function output($format = null, $quality = null) {
+    protected function generate($format = null, $quality = null) {
 
         // Determine quality
         $quality = $quality ?: $this->quality;
@@ -676,61 +683,10 @@ class SimpleImage {
                 break;
         }
 
-        // Output the image
-        header('Content-Type: '.$mimetype);
-        switch ($mimetype) {
-            case 'image/gif':
-                imagegif($this->image);
-                break;
-            case 'image/jpeg':
-                imageinterlace($this->image, true);
-                imagejpeg($this->image, null, round($quality));
-                break;
-            case 'image/png':
-                imagepng($this->image, null, round(9 * $quality / 100));
-                break;
-            default:
-                throw new Exception('Unsupported image format: '.$this->filename);
-                break;
-        }
-    }
+        // Sets image mimetype
+        $this->mimetype = $mimetype;
 
-    /**
-     * Outputs image as data base64 to use as img src
-     *
-     * @param null|string   $format     If omitted or null - format of original file will be used, may be gif|jpg|png
-     * @param int|null      $quality    Output image quality in percents 0-100
-     *
-     * @return string
-     * @throws Exception
-     *
-     */
-    function output_base64($format = null, $quality = null) {
-
-        // Determine quality
-        $quality = $quality ?: $this->quality;
-
-        // Determine mimetype
-        switch (strtolower($format)) {
-            case 'gif':
-                $mimetype = 'image/gif';
-                break;
-            case 'jpeg':
-            case 'jpg':
-                imageinterlace($this->image, true);
-                $mimetype = 'image/jpeg';
-                break;
-            case 'png':
-                $mimetype = 'image/png';
-                break;
-            default:
-                $info = getimagesize($this->filename);
-                $mimetype = $info['mime'];
-                unset($info);
-                break;
-        }
-
-        // Output the image
+        // Sets the image data
         ob_start();
         switch ($mimetype) {
             case 'image/gif':
@@ -746,11 +702,46 @@ class SimpleImage {
                 throw new Exception('Unsupported image format: '.$this->filename);
                 break;
         }
-        $image_data = ob_get_contents();
+        $this->imagestring = ob_get_contents();
         ob_end_clean();
 
+        return $this;
+    }
+
+    /**
+     * Outputs image without saving
+     *
+     * @param null|string   $format     If omitted or null - format of original file will be used, may be gif|jpg|png
+     * @param int|null      $quality    Output image quality in percents 0-100
+     *
+     * @throws Exception
+     *
+     */
+    function output($format = null, $quality = null) {
+
+        $this->generate( $format, $quality );
+
+        // Output the image
+        header('Content-Type: '.$this->mimetype);
+        echo $this->imagestring;
+    }
+
+    /**
+     * Outputs image as data base64 to use as img src
+     *
+     * @param null|string   $format     If omitted or null - format of original file will be used, may be gif|jpg|png
+     * @param int|null      $quality    Output image quality in percents 0-100
+     *
+     * @return string
+     * @throws Exception
+     *
+     */
+    function output_base64($format = null, $quality = null) {
+
+        $this->generate( $format, $quality );
+
         // Returns formatted string for img src
-        return 'data:'.$mimetype.';base64,'.base64_encode($image_data);
+        return 'data:'.$this->mimetype.';base64,'.base64_encode($this->imagestring);
 
     }
 
@@ -925,32 +916,16 @@ class SimpleImage {
     function save($filename = null, $quality = null, $format = null) {
 
         // Determine quality, filename, and format
-        $quality = $quality ?: $this->quality;
         $filename = $filename ?: $this->filename;
-        if( !$format ) {
+        if( !$format )
             $format = $this->file_ext($filename) ?: $this->original_info['format'];
-        }
 
-        // Create the image
-        switch (strtolower($format)) {
-            case 'gif':
-                $result = imagegif($this->image, $filename);
-                break;
-            case 'jpg':
-            case 'jpeg':
-                imageinterlace($this->image, true);
-                $result = imagejpeg($this->image, $filename, round($quality));
-                break;
-            case 'png':
-                $result = imagepng($this->image, $filename, round(9 * $quality / 100));
-                break;
-            default:
-                throw new Exception('Unsupported format');
-        }
+        $this->generate( $format, $quality );
 
-        if (!$result) {
+        // Save the image
+        $result = file_put_contents( $filename, $this->imagestring );
+        if (!$result)
             throw new Exception('Unable to save image: ' . $filename);
-        }
 
         return $this;
 


### PR DESCRIPTION
I've noticed that output, output_base64 and save methods are using a lot of the same code. To avoid code repetition and make the future changes easier I've created a new method called _generate_. 
This method stores the image data and image mime type into class properties so they can be later used by methods output, output_base64 and save.