### PR TITLE
PHP 5.3 Support

### DIFF
--- a/src/abeautifulsite/SimpleImage.php
+++ b/src/abeautifulsite/SimpleImage.php
@@ -658,7 +658,7 @@ class SimpleImage {
         $imagestring = ob_get_contents();
         ob_end_clean();
 
-        return [ $mimetype, $imagestring ];
+        return array($mimetype, $imagestring);
     }
 
     /**


### PR DESCRIPTION
For PHP 5.3 support, we must not use bracket arrays. Fixed a bracket array .