### PR TITLE
Add amount argument to sharpen method

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,7 +568,7 @@ Returns a SimpleImage object.
 
 Sharpens the image.
 
-- `$amount` (int) - Sharpening amount (default 50)
+- `$amount` (int) - Sharpening amount (1 - 100, default 50)
 
 Returns a SimpleImage object.
 

--- a/README.md
+++ b/README.md
@@ -564,9 +564,11 @@ Simulates a sepia effect by desaturating the image and applying a sepia tone.
 
 Returns a SimpleImage object.
 
-#### `sharpen()`
+#### `sharpen($amount)`
 
 Sharpens the image.
+
+- `$amount` (int) - Sharpening amount (default 50)
 
 Returns a SimpleImage object.
 

--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -1496,13 +1496,18 @@ class SimpleImage {
   //
   // Sharpens the image.
   //
+  //  $amount (int) - Sharpening amount (default 50)
+  //
   // Returns a SimpleImage object.
   //
-  public function sharpen() {
+  public function sharpen($amount = 50) {
+    // Normalize amount
+    $amount = max(1, min(99, $amount)) / 100;
+
     $sharpen = [
-      [0, -1, 0],
-      [-1, 5, -1],
-      [0, -1, 0]
+      [-1, -1, -1],
+      [-1,  8 / $amount, -1],
+      [-1, -1, -1],
     ];
     $divisor = array_sum(array_map('array_sum', $sharpen));
 

--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -1502,7 +1502,7 @@ class SimpleImage {
   //
   public function sharpen($amount = 50) {
     // Normalize amount
-    $amount = max(1, min(99, $amount)) / 100;
+    $amount = max(1, min(100, $amount)) / 100;
 
     $sharpen = [
       [-1, -1, -1],


### PR DESCRIPTION
I find default sharpen algorithm too harsh, so I've added `amount` option that accepts values from 1 to 100.

Note that convolution matrix has changed and calling this method without any arguments produces more subtle effect than before.

Usage:
```php
$image
  ->fromFile('foobar.jpg')
  ->sharpen(25);
```