### PR TITLE
get_resource_type error on PHP 8

### DIFF
--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -69,7 +69,7 @@ class SimpleImage {
    * Destroys the image resource.
    */
   public function __destruct() {
-    if($this->image !== null && get_resource_type($this->image) === 'gd') {
+    if($this->image !== null && is_resource($this->image) && get_resource_type($this->image) === 'gd') {
       imagedestroy($this->image);
     }
   }


### PR DESCRIPTION
Hello using php-8.0.0beta4-nts-Win32-vs16-x64, this error is occurring on line 72 ...

The solution I found was to test if it is a resource with "is_resource" before "get_resource_type" ...

I really don't know if in the final version of PHP 8 this will happen, but it may be interesting to leave the code this way.

ERROR:
<<<< PHP Fatal error: Uncaught TypeError: get_resource_type (): Argument # 1 ($ resource) must be of type resource, GdImage given in D: \ mysite \ simpleimage \ SimpleImage.php: 72 >>>>