### PR TITLE
Fix thickness problem with arc() and ellipse()

### DIFF
--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -1167,15 +1167,14 @@ class SimpleImage {
    * @return \claviska\SimpleImage
    */
   public function border($color, $thickness = 1) {
-    $x1 = 0;
+    $x1 = -1;
     $y1 = 0;
-    $x2 = $this->getWidth() - 1;
-    $y2 = $this->getHeight() - 1;
+    $x2 = $this->getWidth();
+    $y2 = $this->getHeight()-1;
 
-    // Draw a border rectangle until it reaches the correct width
-    for($i = 0; $i < $thickness; $i++) {
-      $this->rectangle($x1++, $y1++, $x2--, $y2--, $color);
-    }
+    $color = $this->allocateColor($color);
+    imagesetthickness($this->image, $thickness*2);
+    imagerectangle($this->image, $x1, $y1, $x2, $y2, $color);
 
     return $this;
   }

--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -14,12 +14,13 @@
 //
 
 namespace claviska;
-
+require_once 'TextBlock.php';
 /**
  * A PHP class that makes working with images as simple as possible.
  */
 class SimpleImage {
 
+  
   const
     ERR_FILE_NOT_FOUND = 1,
     ERR_FONT_FILE = 2,
@@ -37,6 +38,8 @@ class SimpleImage {
   protected $image;
   protected $mimeType;
   protected $exif;
+
+  use TextBlock;
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Magic methods

--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -14,7 +14,8 @@
 //
 
 namespace claviska;
-require_once 'TextBlock.php';
+require_once 'TextBox.php';
+
 /**
  * A PHP class that makes working with images as simple as possible.
  */
@@ -39,7 +40,7 @@ class SimpleImage {
   protected $mimeType;
   protected $exif;
 
-  use TextBlock;
+  use TextBox;
 
   //////////////////////////////////////////////////////////////////////////////////////////////////
   // Magic methods

--- a/src/claviska/TextBlock.php
+++ b/src/claviska/TextBlock.php
@@ -58,7 +58,7 @@ trait TextBlock {
 
         $imageText = new SimpleImage();
         $imageText->fromNew($maxWidth + 10, $maxHeight + 10);
-        // $imageText->fromNew($maxWidth+10, $maxHeight+10, 'green|0.2');
+        // $imageText->fromNew($maxWidth+10, $maxHeight+10, 'green|0.2'); // for developer test
 
         // FOR CENTER, LEFT, RIGHT
         if ($justify <> 'justify'):
@@ -131,12 +131,12 @@ trait TextBlock {
         $imageTextCanvas = new SimpleImage();
         $imageTextCanvas
             ->fromNew($maxWidth, $imageText->getHeight())
-            ->overlay($imageText, 'top');
+            ->overlay($imageText, $justify);
         $imageText = $imageTextCanvas;
 
         // $imageText->border('red|0.5'); // for developer test
         $this->overlay($imageText, $anchor, $opacity, $xOffset, $yOffset, $calcuateOffsetFromEdge);
-
+        echo $justify;
         return $this;
     }
 

--- a/src/claviska/TextBlock.php
+++ b/src/claviska/TextBlock.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace claviska;
+
+trait TextBlock
+{
+
+    /* --------------------------------------------------------------------------------- */
+    /* --------------------------------------------------------------------------------- */
+    public function textBlockImage($text, $options, &$boundary = null)
+    {
+        // default width of image
+        $maxWidth = $this->getWidth();
+        // Default options
+        $options = array_merge([
+            'fontFile' => null,
+            'size' => 12,
+            'color' => 'black',
+            'anchor' => 'center',
+            'xOffset' => 0,
+            'yOffset' => 0,
+            'shadow' => null,
+            'calcuateOffsetFromEdge' => true,
+            'opacity' => 1,
+            'leading' => 0,
+            'justify' => 'right',
+            'maxWidth' => $maxWidth,
+        ], $options);
+
+        // Extract and normalize options
+        $fontFile = $options['fontFile'];
+        $fontSize = $fontSizePx = $options['size'];
+        $fontSize = ($fontSize / 96) * 72; // Convert px to pt (72pt per inch, 96px per inch)
+        $color = $options['color'];
+        $anchor = $options['anchor'];
+        $xOffset = $options['xOffset'];
+        $yOffset = $options['yOffset'];
+        $shadow = $options['shadow'];
+        $calcuateOffsetFromEdge = $options['calcuateOffsetFromEdge'];
+        $angle = 0;
+        $opacity = $options['opacity'];
+        $leading = $options['leading'];
+        $justify = $options['justify'];
+        if ($justify == 'right') :
+            $justifyText = 'top right';
+        elseif ($justify == 'center') :
+            $justifyText = 'top';
+        elseif ($justify == 'justify') :
+            $justifyText = 'justify';
+        else :
+            $justifyText = 'top left';
+        endif;
+        $maxWidth = $options['maxWidth'];
+
+        list($lines, $isLastLine) = self::textBlock($text, $fontFile, $fontSize, $maxWidth);
+
+        $maxHeight = (count($lines) + 1) * ($fontSizePx + $leading) * 1.2;
+
+        $imageText = new SimpleImage();
+        $imageText->fromNew($maxWidth + 10, $maxHeight + 10);
+        // $imageText->fromNew($maxWidth+10, $maxHeight+10, 'green|0.2');
+
+        // FOR CENTER, LEFT, RIGHT
+        if (strpos('center left right', $justify) !== false) :
+            foreach ($lines as $key => $line) :
+                $imageText->text($line, array(
+                    'fontFile' => $fontFile,
+                    'size' => $fontSizePx,
+                    'color' => $color,
+                    'anchor' => $justifyText,
+                    'xOffset' => 5,
+                    'yOffset' => 5 + $key * ($fontSizePx + $leading) * 1.2,
+                    'shadow' => $shadow,
+                    'calcuateOffsetFromEdge' => true,
+                ), $box);
+            // $imageText->rectangle($box['x1'], $box['y1'], $box['x2'], $box['y2'], 'black|0.5', 1);
+            endforeach;
+
+        // FOR JUSTIFY
+        else :
+            foreach ($lines as $keyLine => $line) :
+                // check if there are spaces at the beginning of the sentence
+                $spaces = 0;
+                if (preg_match("/^\s+/", $line, $match)) :
+                    $spaces = strlen($match[0]); // count spaces
+                    $line = ltrim($line);
+                endif;
+                $words = preg_split("/\s+/", $line); // separate words
+                // include spaces on first word
+                $words[0] = str_repeat(" ", $spaces) . $words[0];
+
+                $wordsSize = array();
+                foreach ($words as $key => $word) :
+                    $wordBox = imagettfbbox($fontSize, 0, $fontFile, $word);
+                    $wordWidth = abs($wordBox[4] - $wordBox[0]);
+                    $wordsSize[$key] = $wordWidth;
+                endforeach;
+                $countWords = count($words);
+                $wordSizeTotal = array_sum($wordsSize);
+                $wordSpacing = 0;
+                if ($countWords > 1) :
+                    $wordSpacing = ($maxWidth - $wordSizeTotal) / ($countWords - 1);
+                    $wordSpacing = round($wordSpacing, 3);
+                endif;
+
+                $xOffsetJustify = 0;
+                foreach ($words as $key => $word) :
+                    if (isset($isLastLine[$keyLine])) :
+                        if ($key < array_key_last($words)) continue;
+                        $word = $line;
+                    endif;
+                    $imageText->text($word, array(
+                        'fontFile' => $fontFile,
+                        'size' => $fontSizePx,
+                        'color' => $color,
+                        'anchor' => 'top left',
+                        'xOffset' => 5 + $xOffsetJustify,
+                        'yOffset' => 5 + $keyLine * ($fontSizePx + $leading) * 1.2,
+                        'shadow' => $shadow,
+                        'calcuateOffsetFromEdge' => true,
+                    ), $retorno1);
+                    $xOffsetJustify += $wordsSize[$key] + $wordSpacing;
+                endforeach;
+
+            endforeach;
+
+        endif;
+        $imageText->image = imagecropauto($imageText->image, IMG_CROP_SIDES);
+        $imageTextCanvas = new SimpleImage();
+        $imageTextCanvas
+            ->fromNew($maxWidth, $imageText->getHeight())
+            ->overlay($imageText, 'top left');
+        $imageText = $imageTextCanvas;
+
+        // $imageText->border('red|0.5'); // for developer test
+        $this->overlay($imageText, $anchor, $opacity, $xOffset, $yOffset, $calcuateOffsetFromEdge);
+
+        return $this;
+    }
+
+
+    /* --------------------------------------------------------------------------------- */
+    // Recebe um texto e quebra em LINHAS, retorna um array 
+    /* --------------------------------------------------------------------------------- */
+    private function textBlock($text, $fontFile, $fontSize, $maxWidth)
+    {
+        $words = self::textNewLine($text);
+        $countWords = count($words);
+        $lines[0] = '';
+        $lineKey = 0;
+        $isLastLine = null;
+        for ($i = 0; $i < $countWords; $i++) :
+            $word = $words[$i];
+            if ($word === PHP_EOL) {
+                $isLastLine[$lineKey] = true;
+                $lineKey++;
+                $lines[$lineKey] = '';
+                continue;
+            }
+            $lineWidth = imagettfbbox($fontSize, 0, $fontFile, $lines[$lineKey] . $word);
+            // var_dump($lineWidth);
+            if (abs($lineWidth[4] - $lineWidth[0]) < $maxWidth) :
+                $lines[$lineKey] .= $word . ' ';
+            else :
+                $lineKey++;
+                $lines[$lineKey] = $word . ' ';
+            endif;
+        endfor;
+        $isLastLine[$lineKey] = true;
+        // exclude space of right
+        $lines = array_map('rtrim', $lines);
+
+        return array($lines, $isLastLine);
+    }
+
+
+    /* --------------------------------------------------------------------------------- */
+    // Recebe um texto e quebra em PALAVRAS, retorna um array 
+    /* --------------------------------------------------------------------------------- */
+    private function textNewLine($text)
+    {
+        $text = preg_replace('/(\r\n|\n|\r)/', PHP_EOL, $text);
+        $text = explode(PHP_EOL, $text);
+        $newText = array();
+        foreach ($text as $key => $line) :
+            if ($line === '') :
+                $newText = array_merge($newText, [PHP_EOL]);
+            else :
+                $newText = array_merge($newText, [PHP_EOL], explode(' ', $line));
+            endif;
+        endforeach;
+
+        if ($newText[0] == PHP_EOL) array_shift($newText);
+
+        return $newText;
+    }
+} // end trait

--- a/src/claviska/TextBlock.php
+++ b/src/claviska/TextBlock.php
@@ -136,7 +136,7 @@ trait TextBlock {
 
         // $imageText->border('red|0.5'); // for developer test
         $this->overlay($imageText, $anchor, $opacity, $xOffset, $yOffset, $calcuateOffsetFromEdge);
-        echo $justify;
+
         return $this;
     }
 

--- a/src/claviska/TextBox.php
+++ b/src/claviska/TextBox.php
@@ -74,10 +74,9 @@ trait TextBox {
             $justify = 'top left';
         endif;
 
-
         list($lines, $isLastLine, $lastLineHeight) = self::textSeparateLines($text, $fontFile, $fontSize, $maxWidth);
 
-        $maxHeight = array_key_last($lines) * ($fontSizePx * 1.2 + $leading) + $lastLineHeight;
+        $maxHeight = (count($lines) - 1) * ($fontSizePx * 1.2 + $leading) + $lastLineHeight;
 
         $imageText = new SimpleImage();
         $imageText->fromNew($maxWidth, $maxHeight);
@@ -135,7 +134,7 @@ trait TextBox {
                 $xOffsetJustify = 0;
                 foreach ($words as $key => $word):
                     if ($isLastLine[$keyLine] == true):
-                        if ($key < array_key_last($words)) continue;
+                        if ($key < (count($words) - 1)) continue;
                         $word = $line;
                     endif;
                     $imageText->text($word, array(
@@ -172,7 +171,7 @@ trait TextBox {
     */
     private function textSeparateLines($text, $fontFile, $fontSize, $maxWidth) {
         $words = self::textSeparateWords($text);
-        $countWords = array_key_last($words);
+        $countWords = count($words) - 1;
         $lines[0] = '';
         $lineKey = 0;
         $isLastLine = [];

--- a/src/claviska/TextBox.php
+++ b/src/claviska/TextBox.php
@@ -60,6 +60,7 @@ trait TextBox {
         $angle = 0;
         $maxWidth = $options['width'];
         $leading = $options['leading'];
+        $leading = self::keepWithin($leading, ($fontSizePx * -1), $leading);
         $opacity = $options['opacity'];
         
         $justify = $options['justify'];
@@ -76,7 +77,7 @@ trait TextBox {
 
         list($lines, $isLastLine) = self::textSeparateLines($text, $fontFile, $fontSize, $maxWidth);
 
-        $maxHeight = count($lines) * ($fontSizePx + $leading) * 1.2;
+        $maxHeight = count($lines) * ($fontSizePx * 1.2 + $leading);
 
         $imageText = new SimpleImage();
         $imageText->fromNew($maxWidth, $maxHeight);
@@ -91,7 +92,7 @@ trait TextBox {
                     'color' => $color,
                     'anchor' => $justify,
                     'xOffset' => 0,
-                    'yOffset' => $key * ($fontSizePx + $leading) * 1.2,
+                    'yOffset' => $key * ($fontSizePx * 1.2 + $leading),
                     'shadow' => $shadow,
                     'calcuateOffsetFromEdge' => true,
                 ));
@@ -142,7 +143,7 @@ trait TextBox {
                         'color' => $color,
                         'anchor' => 'top left',
                         'xOffset' => $xOffsetJustify,
-                        'yOffset' => $keyLine * ($fontSizePx + $leading) * 1.2,
+                        'yOffset' => $keyLine * ($fontSizePx * 1.2 + $leading),
                         'shadow' => $shadow,
                         'calcuateOffsetFromEdge' => true,
                     ));


### PR DESCRIPTION
Fixes the problem when thickness is greater than 1, it occurs mainly with colors that have transparency.
The thickness of the Ellipse was being drawn inside, all other shapes are drawn in the center. If you think it is better to keep the thickness inside I can change it.

Before
![teste11_before](https://user-images.githubusercontent.com/5252293/98592455-81ab2e80-22b0-11eb-8917-cb5f23c489b2.png)

After
![teste11_after](https://user-images.githubusercontent.com/5252293/98592465-87087900-22b0-11eb-9e25-98d0a3e977a9.png)
