### PR TITLE
Text improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ Place an image on top of the current image.
 - `$opacity` (float) - The opacity level of the overlay 0-1 (default 1).
 - `$xOffset` (int) - Horizontal offset in pixels (default 0).
 - `$yOffset` (int) - Vertical offset in pixels (default 0).
-- `$calcuateOffsetFromEdge` (bool) - Calculate Offset referring to the edges of the image. $xOffset and $yOffset have no effect in center anchor. (default false). 
+- `$calculateOffsetFromEdge` (bool) - Calculate Offset referring to the edges of the image. $xOffset and $yOffset have no effect in center anchor. (default false).
 
 Returns a SimpleImage object.
 
@@ -352,7 +352,7 @@ Adds text to the image.
       - `x`* (int) - Horizontal offset in pixels.
       - `y`* (int) - Vertical offset in pixels.
       - `color`* (string|array) - The text shadow color.
-  - `calcuateOffsetFromEdge` (bool) - Calculate Offset referring to the edges of the image (default false).
+  - `calculateOffsetFromEdge` (bool) - Calculate Offset referring to the edges of the image (default false).
   - `baselineAlign` (bool) - Align the text font with the baseline. (default true).
 - `$boundary` (array) - If passed, this variable will contain an array with coordinates that
   surround the text: [x1, y1, x2, y2, width, height]. This can be used for calculating the

--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -708,10 +708,10 @@ class SimpleImage {
    * @param float $opacity The opacity level of the overlay 0-1 (default 1).
    * @param integer $xOffset Horizontal offset in pixels (default 0).
    * @param integer $yOffset Vertical offset in pixels (default 0).
-   * @param bool $calcuateOffsetFromEdge Calculate Offset referring to the edges of the image (default false).
+   * @param bool $calculateOffsetFromEdge Calculate Offset referring to the edges of the image (default false).
    * @return \claviska\SimpleImage
    */
-  public function overlay($overlay, $anchor = 'center', $opacity = 1, $xOffset = 0, $yOffset = 0, $calcuateOffsetFromEdge = false) {
+  public function overlay($overlay, $anchor = 'center', $opacity = 1, $xOffset = 0, $yOffset = 0, $calculateOffsetFromEdge = false) {
     // Load overlay image
     if(!($overlay instanceof SimpleImage)) $overlay = new SimpleImage($overlay);
 
@@ -723,21 +723,21 @@ class SimpleImage {
     $spaceY = $this->getHeight() - $overlay->getHeight();
 
     // Set default center
-    $x = ($spaceX / 2) + ($calcuateOffsetFromEdge ? 0 : $xOffset);
-    $y = ($spaceY / 2) + ($calcuateOffsetFromEdge ? 0 : $yOffset);
+    $x = ($spaceX / 2) + ($calculateOffsetFromEdge ? 0 : $xOffset);
+    $y = ($spaceY / 2) + ($calculateOffsetFromEdge ? 0 : $yOffset);
 
     // Determine if top|bottom
     if (strpos($anchor, 'top') !== false) {
       $y = $yOffset;
     } elseif (strpos($anchor, 'bottom') !== false) {
-      $y = $spaceY + ($calcuateOffsetFromEdge ? -$yOffset : $yOffset);
+      $y = $spaceY + ($calculateOffsetFromEdge ? -$yOffset : $yOffset);
     }
 
     // Determine if left|right
     if (strpos($anchor, 'left') !== false) {
       $x = $xOffset;
     } elseif (strpos($anchor, 'right') !== false) {
-      $x = $spaceX + ($calcuateOffsetFromEdge ? -$xOffset : $xOffset);
+      $x = $spaceX + ($calculateOffsetFromEdge ? -$xOffset : $xOffset);
     }
 
     // Perform the overlay
@@ -859,7 +859,7 @@ class SimpleImage {
    *          - x* (integer) - Horizontal offset in pixels.
    *          - y* (integer) - Vertical offset in pixels.
    *          - color* (string|array) - The text shadow color.
-   *       - $calcuateOffsetFromEdge (bool) - Calculate Offset referring to the edges of the image (default false).
+   *       - $calculateOffsetFromEdge (bool) - Calculate offsets from the edge of the image (default false).
    *       - $baselineAlign (bool) - Align the text font with the baseline. (default true).
    * @param array $boundary
    *    If passed, this variable will contain an array with coordinates that surround the text: [x1, y1, x2, y2, width, height].
@@ -885,7 +885,7 @@ class SimpleImage {
       'xOffset' => 0,
       'yOffset' => 0,
       'shadow' => null,
-      'calcuateOffsetFromEdge' => false,
+      'calculateOffsetFromEdge' => false,
       'baselineAlign' => true
     ], $options);
 
@@ -896,7 +896,7 @@ class SimpleImage {
     $anchor = $options['anchor'];
     $xOffset = $options['xOffset'];
     $yOffset = $options['yOffset'];
-    $calcuateOffsetFromEdge = $options['calcuateOffsetFromEdge'];
+    $calculateOffsetFromEdge = $options['calculateOffsetFromEdge'];
     $baselineAlign = $options['baselineAlign'];
     $angle = 0;
 
@@ -921,7 +921,7 @@ class SimpleImage {
 
     // Calculate Offset referring to the edges of the image.
     // Just invert the value for bottom|right;
-    if ($calcuateOffsetFromEdge == true) {
+    if ($calculateOffsetFromEdge == true) {
       if (strpos($anchor, 'bottom') !== false) $yOffset *= -1;
       if (strpos($anchor, 'right') !== false) $xOffset *= -1;
     }
@@ -1029,19 +1029,19 @@ class SimpleImage {
   * @param string $text The desired text.
   * @param array $options
   *  An array of options.
-  *     - x* (integer) - Horizontal offset in pixels.
-  *     - y* (integer) - Vertical offset in pixels.
   *     - fontFile* (string) - The TrueType (or compatible) font file to use.
   *     - size (integer) - The size of the font in pixels (default 12).
   *     - color (string|array) - The text color (default black).
   *     - anchor (string) - The anchor point: 'center', 'top', 'bottom', 'left', 'right', 'top left', 'top right', 'bottom left', 'bottom right' (default 'center').
-  *     - xOffset (integer) - The horizontal offset in pixels (default 0).
-  *     - shadow* (string|array) - The text shadow color.
-  *     - yOffset (integer) - The vertical offset in pixels (default 0).
+  *     - xOffset (integer) - The horizontal offset in pixels (default 0). Has no effect when anchor is 'center'.
+  *     - yOffset (integer) - The vertical offset in pixels (default 0). Has no effect when anchor is 'center'.
   *     - shadow (array) - Text shadow params.
-  *     - $calcuateOffsetFromEdge (bool) - Calculate Offset referring to the edges of the image (default true).
-  *     - width (int) - Width of text box (Default image width).
-  *     - justify (string) - The justify: 'left', 'right', 'center', 'justify' (default 'left').
+  *       - x* (integer) - Horizontal offset in pixels.
+  *       - y* (integer) - Vertical offset in pixels.
+  *       - color* (string|array) - The text shadow color.
+  *     - $calculateOffsetFromEdge (bool) - Calculate offsets from the edge of the image (default false).
+  *     - width (int) - Width of text box (default image width).
+  *     - align (string) - How to align text: 'left', 'right', 'center', 'justify' (default 'left').
   *     - leading (float) - Increase/decrease spacing between lines of text (default 0).
   *     - opacity (float) - The opacity level of the text 0-1 (default 1).
   * @throws \Exception
@@ -1059,11 +1059,11 @@ class SimpleImage {
       'xOffset' => 0,
       'yOffset' => 0,
       'shadow' => null,
-      'calcuateOffsetFromEdge' => true,
+      'calculateOffsetFromEdge' => false,
       'width' => $maxWidth,
-      'justify' => 'left',
+      'align' => 'left',
       'leading' => 0,
-      'opacity' => 1,
+      'opacity' => 1
     ], $options);
 
     // Extract and normalize options
@@ -1075,22 +1075,22 @@ class SimpleImage {
     $xOffset = $options['xOffset'];
     $yOffset = $options['yOffset'];
     $shadow = $options['shadow'];
-    $calcuateOffsetFromEdge = $options['calcuateOffsetFromEdge'];
+    $calculateOffsetFromEdge = $options['calculateOffsetFromEdge'];
     $angle = 0;
     $maxWidth = $options['width'];
     $leading = $options['leading'];
     $leading = self::keepWithin($leading, ($fontSizePx * -1), $leading);
     $opacity = $options['opacity'];
 
-    $justify = $options['justify'];
-    if ($justify == 'right') {
-      $justify = 'top right';
-    } elseif ($justify == 'center') {
-      $justify = 'top';
-    } elseif ($justify == 'justify') {
-      $justify = 'justify';
+    $align = $options['align'];
+    if ($align == 'right') {
+      $align = 'top right';
+    } elseif ($align == 'center') {
+      $align = 'top';
+    } elseif ($align == 'justify') {
+      $align = 'justify';
     } else {
-      $justify = 'top left';
+      $align = 'top left';
     }
 
     list($lines, $isLastLine, $lastLineHeight) = self::textSeparateLines($text, $fontFile, $fontSize, $maxWidth);
@@ -1100,24 +1100,23 @@ class SimpleImage {
     $imageText = new SimpleImage();
     $imageText->fromNew($maxWidth, $maxHeight);
 
-    // FOR CENTER, LEFT, RIGHT
-    if ($justify <> 'justify') {
+    // Align left/center/right
+    if ($align <> 'justify') {
       foreach ($lines as $key => $line) {
-        if( $justify == 'top' ) $line = trim($line); // If is justify = 'center'
+        if( $align == 'top' ) $line = trim($line); // If is justify = 'center'
         $imageText->text($line, array(
           'fontFile' => $fontFile,
           'size' => $fontSizePx,
           'color' => $color,
-          'anchor' => $justify,
+          'anchor' => $align,
           'xOffset' => 0,
           'yOffset' => $key * ($fontSizePx * 1.2 + $leading),
           'shadow' => $shadow,
-          'calcuateOffsetFromEdge' => true,
-          )
-        );
+          'calculateOffsetFromEdge' => true
+        ));
       }
 
-    // FOR JUSTIFY
+    // Justify
     } else {
       foreach ($lines as $keyLine => $line) {
         // Check if there are spaces at the beginning of the sentence
@@ -1131,7 +1130,7 @@ class SimpleImage {
         // Separate words
         $words = preg_split("/\s+/", $line);
         // Include spaces with the first word
-        $words[0] = str_repeat(" ", $spaces) . $words[0];
+        $words[0] = str_repeat(' ', $spaces) . $words[0];
 
         // Calculates the space occupied by all words
         $wordsSize = array();
@@ -1164,16 +1163,16 @@ class SimpleImage {
             'xOffset' => $xOffsetJustify,
             'yOffset' => $keyLine * ($fontSizePx * 1.2 + $leading),
             'shadow' => $shadow,
-            'calcuateOffsetFromEdge' => true,
+            'calculateOffsetFromEdge' => true,
             )
           );
-          // Calculate offSet for next word
+          // Calculate offset for next word
           $xOffsetJustify += $wordsSize[$key] + $wordSpacing;
         }
       }
     }
 
-    $this->overlay($imageText, $anchor, $opacity, $xOffset, $yOffset, $calcuateOffsetFromEdge);
+    $this->overlay($imageText, $anchor, $opacity, $xOffset, $yOffset, $calculateOffsetFromEdge);
 
     return $this;
   }

--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -1024,6 +1024,223 @@ class SimpleImage {
   }
 
   /**
+  * Adds text with a line break to the image.
+  *
+  * @param string $text The desired text.
+  * @param array $options
+  *  An array of options.
+  *     - x* (integer) - Horizontal offset in pixels.
+  *     - y* (integer) - Vertical offset in pixels.
+  *     - fontFile* (string) - The TrueType (or compatible) font file to use.
+  *     - size (integer) - The size of the font in pixels (default 12).
+  *     - color (string|array) - The text color (default black).
+  *     - anchor (string) - The anchor point: 'center', 'top', 'bottom', 'left', 'right', 'top left', 'top right', 'bottom left', 'bottom right' (default 'center').
+  *     - xOffset (integer) - The horizontal offset in pixels (default 0).
+  *     - shadow* (string|array) - The text shadow color.
+  *     - yOffset (integer) - The vertical offset in pixels (default 0).
+  *     - shadow (array) - Text shadow params.
+  *     - $calcuateOffsetFromEdge (bool) - Calculate Offset referring to the edges of the image (default true).
+  *     - width (int) - Width of text box (Default image width).
+  *     - justify (string) - The justify: 'left', 'right', 'center', 'justify' (default 'left').
+  *     - leading (float) - Increase/decrease spacing between lines of text (default 0).
+  *     - opacity (float) - The opacity level of the text 0-1 (default 1).
+  * @throws \Exception
+  * @return \claviska\SimpleImage
+  */
+  public function textBox($text, $options) {
+    // default width of image
+    $maxWidth = $this->getWidth();
+    // Default options
+    $options = array_merge([
+      'fontFile' => null,
+      'size' => 12,
+      'color' => 'black',
+      'anchor' => 'center',
+      'xOffset' => 0,
+      'yOffset' => 0,
+      'shadow' => null,
+      'calcuateOffsetFromEdge' => true,
+      'width' => $maxWidth,
+      'justify' => 'left',
+      'leading' => 0,
+      'opacity' => 1,
+    ], $options);
+
+    // Extract and normalize options
+    $fontFile = $options['fontFile'];
+    $fontSize = $fontSizePx = $options['size'];
+    $fontSize = ($fontSize / 96) * 72; // Convert px to pt (72pt per inch, 96px per inch)
+    $color = $options['color'];
+    $anchor = $options['anchor'];
+    $xOffset = $options['xOffset'];
+    $yOffset = $options['yOffset'];
+    $shadow = $options['shadow'];
+    $calcuateOffsetFromEdge = $options['calcuateOffsetFromEdge'];
+    $angle = 0;
+    $maxWidth = $options['width'];
+    $leading = $options['leading'];
+    $leading = self::keepWithin($leading, ($fontSizePx * -1), $leading);
+    $opacity = $options['opacity'];
+
+    $justify = $options['justify'];
+    if ($justify == 'right') {
+      $justify = 'top right';
+    } elseif ($justify == 'center') {
+      $justify = 'top';
+    } elseif ($justify == 'justify') {
+      $justify = 'justify';
+    } else {
+      $justify = 'top left';
+    }
+
+    list($lines, $isLastLine, $lastLineHeight) = self::textSeparateLines($text, $fontFile, $fontSize, $maxWidth);
+
+    $maxHeight = (count($lines) - 1) * ($fontSizePx * 1.2 + $leading) + $lastLineHeight;
+
+    $imageText = new SimpleImage();
+    $imageText->fromNew($maxWidth, $maxHeight);
+
+    // FOR CENTER, LEFT, RIGHT
+    if ($justify <> 'justify') {
+      foreach ($lines as $key => $line) {
+        if( $justify == 'top' ) $line = trim($line); // If is justify = 'center'
+        $imageText->text($line, array(
+          'fontFile' => $fontFile,
+          'size' => $fontSizePx,
+          'color' => $color,
+          'anchor' => $justify,
+          'xOffset' => 0,
+          'yOffset' => $key * ($fontSizePx * 1.2 + $leading),
+          'shadow' => $shadow,
+          'calcuateOffsetFromEdge' => true,
+          )
+        );
+      }
+
+    // FOR JUSTIFY
+    } else {
+      foreach ($lines as $keyLine => $line) {
+        // Check if there are spaces at the beginning of the sentence
+        $spaces = 0;
+        if (preg_match("/^\s+/", $line, $match)) {
+          // Count spaces
+          $spaces = strlen($match[0]);
+          $line = ltrim($line);
+        }
+
+        // Separate words
+        $words = preg_split("/\s+/", $line);
+        // Include spaces with the first word
+        $words[0] = str_repeat(" ", $spaces) . $words[0];
+
+        // Calculates the space occupied by all words
+        $wordsSize = array();
+        foreach ($words as $key => $word) {
+          $wordBox = imagettfbbox($fontSize, 0, $fontFile, $word);
+          $wordWidth = abs($wordBox[4] - $wordBox[0]);
+          $wordsSize[$key] = $wordWidth;
+        }
+        $wordsSizeTotal = array_sum($wordsSize);
+
+        // Calculates the required space between words
+        $countWords = count($words);
+        $wordSpacing = 0;
+        if ($countWords > 1) {
+          $wordSpacing = ($maxWidth - $wordsSizeTotal) / ($countWords - 1);
+          $wordSpacing = round($wordSpacing, 3);
+        }
+
+        $xOffsetJustify = 0;
+        foreach ($words as $key => $word) {
+          if ($isLastLine[$keyLine] == true) {
+            if ($key < (count($words) - 1)) continue;
+            $word = $line;
+          }
+          $imageText->text($word, array(
+            'fontFile' => $fontFile,
+            'size' => $fontSizePx,
+            'color' => $color,
+            'anchor' => 'top left',
+            'xOffset' => $xOffsetJustify,
+            'yOffset' => $keyLine * ($fontSizePx * 1.2 + $leading),
+            'shadow' => $shadow,
+            'calcuateOffsetFromEdge' => true,
+            )
+          );
+          // Calculate offSet for next word
+          $xOffsetJustify += $wordsSize[$key] + $wordSpacing;
+        }
+      }
+    }
+
+    $this->overlay($imageText, $anchor, $opacity, $xOffset, $yOffset, $calcuateOffsetFromEdge);
+
+    return $this;
+  }
+
+  /**
+  * Receives a text and breaks into LINES.
+  *
+  * @param integer $text
+  * @param string $fontFile
+  * @param int $fontSize
+  * @param int $maxWidth
+  * @return array
+  */
+  private function textSeparateLines($text, $fontFile, $fontSize, $maxWidth) {
+    $words = self::textSeparateWords($text);
+    $countWords = count($words) - 1;
+    $lines[0] = '';
+    $lineKey = 0;
+    $isLastLine = [];
+    for ($i = 0; $i < $countWords; $i++) {
+      $word = $words[$i];
+      $isLastLine[$lineKey] = false;
+      if ($word === PHP_EOL) {
+        $isLastLine[$lineKey] = true;
+        $lineKey++;
+        $lines[$lineKey] = '';
+        continue;
+      }
+      $lineBox = imagettfbbox($fontSize, 0, $fontFile, $lines[$lineKey] . $word);
+      if (abs($lineBox[4] - $lineBox[0]) < $maxWidth) {
+        $lines[$lineKey] .= $word . ' ';
+      } else {
+        $lineKey++;
+        $lines[$lineKey] = $word . ' ';
+      }
+    }
+    $isLastLine[$lineKey] = true;
+    // Exclude space of right
+    $lines = array_map('rtrim', $lines);
+    // Calculate height of last line
+    $boxFull = imagettfbbox($fontSize, 0, $fontFile, 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890');
+    $lineBox = imagettfbbox($fontSize, 0, $fontFile, $lines[$lineKey]);
+    // Height of last line = ascender of $boxFull + descender of $lineBox
+    $lastLineHeight = abs($lineBox[1]) + abs($boxFull[5]);
+
+    return array($lines, $isLastLine, $lastLineHeight);
+  }
+
+  /**
+  * Receives a text and breaks into WORD / SPACE / NEW LINE.
+  *
+  * @param integer $text
+  * @return array
+  */
+  private function textSeparateWords($text) {
+    // Normalizes line break
+    $text = preg_replace('/(\r\n|\n|\r)/', PHP_EOL, $text);
+    $text = explode(PHP_EOL, $text);
+    $newText = array();
+    foreach ($text as $key => $line) {
+      $newText = array_merge($newText, explode(' ', $line), [PHP_EOL]);
+    }
+
+    return $newText;
+  }
+
+  /**
    * Creates a thumbnail image. This function attempts to get the image as close to the provided
    * dimensions as possible, then crops the remaining overflow to force the desired size. Useful
    * for generating thumbnail images.


### PR DESCRIPTION
This adds back the `textBox` method and supporting private methods that @maPer77 committed in #269. Included in this change is the ability to wrap text automatically. I removed them after merging the other changes because many of the options didn't work when I tested them, including `$x`, `$y`, `$leading`, and a few others.

This function needs more work and additional discussion as to whether we want to keep the `textBox()` name or somehow merge it with the existing `text` method.

I've also removed the trait and merged the methods into the main class file. We can work on splitting things out and reorganizing in a separate branch.