### PR TITLE
Fix invalid image warning

### DIFF
--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -128,7 +128,7 @@ class SimpleImage {
     fclose($handle);
 
     // Get image info
-    $info = getimagesize($file);
+    $info = @getimagesize($file);
     if($info === false) {
       throw new \Exception("Invalid image file: $file", self::ERR_INVALID_IMAGE);
     }


### PR DESCRIPTION
If the image exists but it isn't a valid image, it show an error.