### PR TITLE
Add instance flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -702,12 +702,40 @@ As a best practice, always use the defined constants instead of their integers v
 - `ERR_UNSUPPORTED_FORMAT` - The image format specified is not valid.
 - `ERR_WEBP_NOT_ENABLED` - WEBP support is not enabled in your version of PHP.
 - `ERR_WRITE` - Unable to write to the file system.
+- `ERR_INVALID_FAG` - The specified flag key does not exist.
 
 ### Useful Things To Know
 
 - Color arguments can be a CSS color name (e.g. `LightBlue`), a hex color string (e.g. `#0099dd`), or an RGB(A) array (e.g. `['red' => 255, 'green' => 0, 'blue' => 0, 'alpha' => 1]`).
 
 - When `$thickness` > 1, GD draws lines of the desired thickness from the center origin. For example, a rectangle drawn at [10, 10, 20, 20] with a thickness of 3 will actually be draw at [9, 9, 21, 21]. This is true for all shapes and is not a bug in the SimpleImage library.
+
+### Instance flags
+
+Tweak the behavior of a SimpleImage instance by setting instance flag values with the `setFlag($key, $value)` method.
+
+```php
+$image = new \claviska\SimpleImage('image.jpeg')->setFlag("foo", "bar");
+```
+
+You can also pass an associative array to the SimpleImage constructor to set instance flags.
+
+```php
+$image = new \claviska\SimpleImage('image.jpeg', ['foo' => 'bar']);
+// .. or without an $image
+$image = new \claviska\SimpleImage(flags: ['foo' => 'bar']);
+```
+
+*Note: `setFlag()` throws an `ERR_INVALID_FLAG` exception if the key does not exist (no default value).*
+
+#### `sslVerify`
+
+Setting `sslVerify` to `false` (defaults to `true`) will make all images loaded over HTTPS forgo certificate peer validation. This is especially usefull for self-signed certificates.
+
+```php
+$image = new \claviska\SimpleImage('https://localhost/image.jpeg', ['sslVerify' => false]);
+// Would normally throw an OpenSSL exception, but is ignored with the sslVerify flag set to false.
+```
 
 ## Differences from SimpleImage 2.x
 


### PR DESCRIPTION
Adds support for settable and gettable instance flags. This allows overrides of default behavior to be set upon instantiation of the `SimpleImage` class.

Only `sslVerify` will be implemented as of right now (from #300) but more flags can be added in the future.

*Example use of flag overrides with `sslVerify`:*

```php
// Class initialized with image URL
$img = new claviska\SimpleImage("https://localhost/img.png", ["sslVerify" => false]);
$img->thumbnail(128,128)->toFile("thumb.png");
```
```php
// Class initialized without image URL
$img = new claviska\SimpleImage(flags: ["sslVerify" => false]);
$img->fromFile("https://localhost/img.png")->thumbnail(128,128)->toFile("thumb.png");
```

**This PR invalidates #300**

## TODO before merge
- [x] https://github.com/claviska/SimpleImage/pull/301#discussion_r905997091
- [x] Add feature documentation to README.