### PR TITLE
#303: Update data type from int to float.

### DIFF
--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -1376,7 +1376,7 @@ class SimpleImage
     /**
      * Receives a text and breaks into LINES.
      */
-    private function textSeparateLines(string $text, string $fontFile, int $fontSize, int $maxWidth): array
+    private function textSeparateLines(string $text, string $fontFile, float $fontSize, float $maxWidth): array
     {
         $lines = [];
         $words = self::textSeparateWords($text);


### PR DESCRIPTION
Related ticket: #303

The text is being cropped every time whenever I use the function `textBox` 

## Steps to reproduce:

Use the method `textBox`

```
      $phrase = '“Mi mejor amigo, siempre me espera en la puerta. Quiero que siempre esté conmigo. Mi mejor amigo, siempre me espera en la puerta. Quiero que siempre esté conmigo“';
      $image->textBox($phrase, [
              'fontFile' => 'Roboto-Regular.ttf',
              'size' => 18
              'anchor' => 'top left',
              'xOffset' => 0,
              'yOffset' => 0,
              'color' => '#ff9900',
              'width' => 414,
              'align' => left,
          ]
      );
```
(of course the values do not match exactly the screenshot but can give you an idea).

And you can notice that words "dueño qu" "qu" is missing the "e" which should be  "dueño" and the word "que" should be in the next line since there is not enough space.

<img width="667" alt="image" src="https://user-images.githubusercontent.com/1582129/236589853-39282115-4469-456d-9826-3e5288b0dad4.png">

## Proposal solution

Change the data type from `int` to `float` since there's a previous division for the maxWidth to convert px to pt and the division returns a float value. This decimal point is very important so that it doesn't crop.

With the fix provided, now you can see the expected result:

<img width="625" alt="image" src="https://user-images.githubusercontent.com/1582129/236589808-0bc84e3a-e650-4dbc-b4ff-82994ac8413e.png">


This fixes the issue from #303 