### PR TITLE
convert falsy values of $exif to null

### DIFF
--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -68,7 +68,7 @@ class SimpleImage
 
     protected string $mimeType;
 
-    protected null|array|false $exif;
+    protected null|array|false $exif = null;
 
     //////////////////////////////////////////////////////////////////////////////////////////////////
     // Magic methods
@@ -585,7 +585,8 @@ class SimpleImage
      */
     public function getExif(): ?array
     {
-        return $this->exif ?? null;
+        // returns null if exif value is falsy: null, false or empty array.
+        return $this->exif ?: null;
     }
 
     /**


### PR DESCRIPTION
fix #323

two things changed:
1. Initialized the $exif field to `null`, just to get rid of the coalescing operator: the value is now "always set". 
2. return `null` when the value is "falsy": `false` and `[]` are therefore converted to `null`, respecting the function's return type.
