### PR TITLE
fix typo in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-/examples           export-ignore
+/example            export-ignore
 /.github            export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore


### PR DESCRIPTION
`example` directory was not excluded properly causing the example BMP (1.3MB) to push to users of the lib (like @getkirby)