### PR TITLE
Add getExtension() method - helps with uploaded file renaming

### DIFF
--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -603,6 +603,28 @@ class SimpleImage
         return $this->mimeType;
     }
 
+	/**
+	 * Gets the corresponding extension for the current MIME type
+	 *
+	 * @throws Exception Thrown if invalid MIME type found (edge case)
+	 */
+	public function getExtension(): string
+	{
+		return match (strtolower($this->mimeType)) {
+			'image/jpeg' => 'jpg',
+			'image/png' => 'png',
+			'image/gif' => 'gif',
+			'image/webp' => 'webp',
+			'image/avif' => 'avif',
+			'image/bmp', 'image/x-ms-bmp', 'image/x-windows-bmp' => 'bmp',
+			//other image types supported are WAP BMP and GD's internal pics
+			default => throw new \Exception(
+				'Unsupported format: '.$this->mimeType,
+				self::ERR_UNSUPPORTED_FORMAT
+			)
+		};
+	}
+
     /**
      * Gets the image's current orientation.
      *


### PR DESCRIPTION
Supersedes #143. This is even important with v3/v4, since `original_info['format']` got removed with no clear replacement.

We also got a 3.7 version of this function; in case there's any interest on backporting, I can create another PR with that :)