### PR TITLE
Support hex colors with alpha channel: RGBA and RRGGBBAA

### DIFF
--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -2344,7 +2344,7 @@ class SimpleImage
                     $hex[2].$hex[2],
                 ];
                 if (strlen($hex) === 4) {
-                    $alpha = hexdec($hex[3]) / 256;
+                    $alpha = hexdec($hex[3]) / 255;
                 }
             } elseif (strlen($hex) === 6 || strlen($hex) === 8) {
                 [$red, $green, $blue] = [
@@ -2353,7 +2353,7 @@ class SimpleImage
                     $hex[4].$hex[5],
                 ];
                 if (strlen($hex) === 8) {
-                    $alpha = hexdec($hex[6].$hex[7]) / 256;
+                    $alpha = hexdec($hex[6].$hex[7]) / 255;
                 }
             } else {
                 throw new Exception("Invalid color value: $color", self::ERR_INVALID_COLOR);

--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -2337,18 +2337,24 @@ class SimpleImage
             $hex = strval(preg_replace('/^#/', '', $color));
 
             // Support short and standard hex codes
-            if (strlen($hex) === 3) {
+            if (strlen($hex) === 3 || strlen($hex) === 4) {
                 [$red, $green, $blue] = [
                     $hex[0].$hex[0],
                     $hex[1].$hex[1],
                     $hex[2].$hex[2],
                 ];
-            } elseif (strlen($hex) === 6) {
+                if (strlen($hex) === 4) {
+                    $alpha = hexdec($hex[3]) / 256;
+                }
+            } elseif (strlen($hex) === 6 || strlen($hex) === 8) {
                 [$red, $green, $blue] = [
                     $hex[0].$hex[1],
                     $hex[2].$hex[3],
                     $hex[4].$hex[5],
                 ];
+                if (strlen($hex) === 8) {
+                    $alpha = hexdec($hex[6].$hex[7]) / 256;
+                }
             } else {
                 throw new Exception("Invalid color value: $color", self::ERR_INVALID_COLOR);
             }


### PR DESCRIPTION
Added support for 4 and 8 digit hex colors with alpha channel. Eg: #00ff0080